### PR TITLE
removing typing as required dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pytz>=2019.3
 python-dateutil>=2.8.0
-typing>=3.6.2
 six>=1.12.0
 jdatetime>=3.6.2


### PR DESCRIPTION
typing is already included in python 3.7+, installing the typing module breaks things
See https://stackoverflow.com/questions/55833509/attributeerror-type-object-callable-has-no-attribute-abc-registry